### PR TITLE
automatic peco install on julia>=1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.3.3-DEV"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+peco_jll = "b89f85f3-45f8-5ea8-8223-9dfa39faf294"
 
 [compat]
 julia = "= 0.7, 1.0"

--- a/src/InteractiveCodeSearch.jl
+++ b/src/InteractiveCodeSearch.jl
@@ -281,7 +281,7 @@ InteractiveCodeSearch.CONFIG.auto_open = false  # open matcher even when there
 
 ## Using InteractiveCodeSearch.jl by default
 
-Put the following code in your `~/.julia/config/startup.jl` (≥ Julia 0.7):
+Put the following code in your `~/.julia/config/startup.jl`:
 
 ```julia
 using InteractiveCodeSearch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ module TestInteractiveCodeSearch
 include("preamble.jl")
 using InteractiveCodeSearch:
     Shallow, Recursive, list_locatables, module_methods, choose_method,
-    read_stdout, parse_loc, single_macrocall, isliteral
+    read_stdout, parse_loc, single_macrocall, isliteral, convertCmd
 using Base: find_source_file
 
 function with_config(f; kwargs...)
@@ -22,8 +22,8 @@ function with_config(f; kwargs...)
 end
 
 @testset "read_stdout" begin
-    @test strip(String(read_stdout("spam", `cat`))) == "spam"
-    @test strip(String(read_stdout(io -> write(io, "egg"), `cat`))) == "egg"
+    @test strip(String(read_stdout("spam", convertCmd(`cat`)))) == "spam"
+    @test strip(String(read_stdout(io -> write(io, "egg"), convertCmd(`cat`)))) == "egg"
 end
 
 @testset "parse_loc" begin
@@ -70,7 +70,7 @@ end
 
     with_config(
         open = (_...) -> error("must not be called"),
-        interactive_matcher = `echo " at test.jl:249"`,
+        interactive_matcher = convertCmd(`echo " at test.jl:249"`),
         auto_open = true,
     ) do
         # when function has only one method, `auto_open` has to kick-in:
@@ -91,7 +91,7 @@ end
 
     with_config(
         open = (_...) -> error("must not be called"),
-        interactive_matcher = `echo " at test.jl:249"`,
+        interactive_matcher = convertCmd(`echo " at test.jl:249"`),
         auto_open = false,
     ) do
         # When `auto_open = false`, the matcher has to be called
@@ -127,7 +127,7 @@ end
     dummy_openline(args...) = push!(open_args, args)
 
     with_config(
-        interactive_matcher = `echo " at test.jl:249"`,
+        interactive_matcher = convertCmd(`echo " at test.jl:249"`),
         open = dummy_openline,
         auto_open = false,
     ) do
@@ -149,7 +149,7 @@ end
     end
 
     with_config(
-        interactive_matcher = `true`,
+        interactive_matcher = convertCmd(`true`),
         open = (args...) -> error("open must not be called"),
         auto_open = false,
     ) do


### PR DESCRIPTION
This was the shortest change I had been able to come up with.
It now downloads in any case but uses the systems peco if available. (Otherwise it uses the artifact)

Fixes #6 for Julia>=1.3

Edit: I even managed to increase coverage 🤣

EDIT2: Seems to be far from idiomatic usage of the new artifacts & jll. Thus, do not merge yet! Eventually this needs a bigger rewrite.